### PR TITLE
feat(deployment): load aws secrets and save to app.env

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,6 +27,9 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
 
+      - name: Load secrets and save to app.env
+        run: aws secretsmanager get-secret-value --secret-id school_mgs --query SecretString --output text | jq -r 'to_entries|map("\(.key)=\(.value)")|.[]' > app.env
+
       - name: Build, tag, and push docker image to Amazon ECR
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ dropdb:
 	docker exec -it postgres-school-mgs dropdb -U postgres school_mgs
 
 migrate_up:
-	migrate -path db/migrations -database "postgresql://postgres:password@localhost:5432/school_mgs?sslmode=disable" -verbose up
+	migrate -path db/migrations -database "postgresql://postgres:lCjpbV7tLGs54Ou14lTA@school-mgs.cxus680k2f2v.eu-north-1.rds.amazonaws.com:5432/school_mgs" -verbose up
 
 migrate_down:
 	migrate -path db/migrations -database "postgresql://postgres:password@localhost:5432/school_mgs?sslmode=disable" -verbose down

--- a/app.env
+++ b/app.env
@@ -1,5 +1,5 @@
+DB_SOURCE=postgresql://postgres:lCjpbV7tLGs54Ou14lTA@school-mgs.cxus680k2f2v.eu-north-1.rds.amazonaws.com:5432/school_mgs
 DB_DRIVER=postgres
-DB_SOURCE=postgresql://postgres:password@localhost:5432/school_mgs?sslmode=disable
 SERVER_ADDRESS=0.0.0.0:8080
-TOKEN_SYMMETRIC_KEY=12345678123456781234567812345678
 ACCESS_TOKEN_DURATION=15m
+TOKEN_SYMMETRIC_KEY=83db88604c6b8a9842ea26dcb991a8bd


### PR DESCRIPTION
firstly, we used aws cli to test getting secrets from the secretsmanager. then we use jq to format the json into the app.env style finally the output string is saved in the app.env file this step is added in the deploy workflow just before building the docker image.